### PR TITLE
fix: allow block quote conceals to work with all markdown elements

### DIFF
--- a/.config/nvim/after/queries/markdown/highlights.scm
+++ b/.config/nvim/after/queries/markdown/highlights.scm
@@ -16,11 +16,8 @@
 
 ; Block quotes
 ((block_quote_marker) @punctuation.special (#offset! @punctuation.special 0 0 0 -1) (#set! conceal "▐"))
-((block_quote
-  (paragraph (inline
-    (block_continuation) @punctuation.special (#offset! @punctuation.special 0 0 0 -1) (#set! conceal "▐")
-  ))
-))
+((block_continuation) @punctuation.special (#eq? @punctuation.special "> ") (#offset! @punctuation.special 0 0 0 -1) (#set! conceal "▐"))
+((block_continuation) @punctuation.special (#eq? @punctuation.special ">") (#set! conceal "▐"))
 (block_quote
   (paragraph) @text.literal)
 


### PR DESCRIPTION
With the existing code, the block quote conceals would only work with paragraphs. If there were block quoted code blocks, bulleted lists, etc. this would not work. Also if the paragraph was nested in a header in a block quote this would also not work. I have found this solution to be more universal